### PR TITLE
use simpler api endpoint url for eval

### DIFF
--- a/src/loader.test.ts
+++ b/src/loader.test.ts
@@ -53,13 +53,13 @@ describe('load', () => {
     beforeEach(() => {
       const app = express();
 
-      app.get('/too-long/configs/eval/*/*', (_, res:any) => {
+      app.get('/too-long/configs/eval/*', (_, res:any) => {
         setTimeout(() => {
           res.send('{ "values": { "failover": { "bool": false } } }');
         }, TIMEOUT + 1000);
       });
 
-      app.get('/failover/configs/eval/*/*', (_, res:any) => {
+      app.get('/failover/configs/eval/*', (_, res:any) => {
         res.send('{ "values": { "failover": { "bool": true } } }');
       });
 

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -7,8 +7,6 @@ const headers = (apiKey: string) => ({
   'X-PrefabCloud-Client-Version': `prefab-cloud-js${version}`,
 });
 
-const apiHash = (apiKey: string) => base64Encode(apiKey);
-
 export const DEFAULT_TIMEOUT = 10000;
 
 export default class Loader {
@@ -35,7 +33,7 @@ export default class Loader {
   }
 
   url(root: string) {
-    return `${root}/configs/eval/${apiHash(this.apiKey)}/${this.identity.encode()}`;
+    return `${root}/configs/eval/${this.identity.encode()}`;
   }
 
   loadFromEndpoint(index : number, options: object, resolve : Function, reject : Function) {


### PR DESCRIPTION
Simpler endpoint now serves the same results.
Avoid invalid caching via Vary header.