### PR TITLE
Small optimization for root lookup

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -31,6 +31,10 @@ export const shouldLog = ({
       return WORD_LEVEL_LOOKUP[resolvedLevel.toString()] <= desiredLevelNumber;
     }
 
+    if (loggerNameWithPrefix.indexOf(".") === -1) {
+      break;
+    }
+
     loggerNameWithPrefix = loggerNameWithPrefix.slice(
       0,
       loggerNameWithPrefix.lastIndexOf(".")

--- a/src/prefab.test.ts
+++ b/src/prefab.test.ts
@@ -155,7 +155,7 @@ test("isEnabled", () => {
 });
 
 describe("shouldLog", () => {
-  test("compares against the default where there is no value", () => {
+  test("compares against the default level where there is no value", () => {
     expect(
       prefab.shouldLog({
         loggerName: "example",


### PR DESCRIPTION
The slice approach without this guard would end up iterating over every
character of the `log-level` prefix.
