### PR TITLE
Reset polling on `init`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "jest": "^28.1.3",
     "jest-fetch-mock": "^3.0.3",
     "lint-staged": "^13.2.3",
-    "prettier": "^2.8.8",
     "prettier": "^3.0.0",
     "ts-node": "^10.9.1",
     "typescript": "^4.7.4"


### PR DESCRIPTION
This is most relevant to react tests since there's a single global
`prefab` object, but if you `init` after starting polling, the previous
polling shouldn't continue.
