### PR TITLE
Fix bug with poll canceling

### DIFF
--- a/src/prefab.test.ts
+++ b/src/prefab.test.ts
@@ -156,6 +156,22 @@ describe('poll', () => {
     expect(clearTimeout).toHaveBeenCalledWith(timeoutId);
     expect(prefab.pollTimeoutId).toBeUndefined();
   });
+
+  it("resets on init if the polling hasn't actually started yet", async () => {
+    const data = {values: {}};
+    fetchMock.mockResponse(JSON.stringify(data));
+
+    const config: InitParams = {
+      apiKey: '1234',
+      context: new Context({user: {device: 'desktop'}}),
+    };
+
+    await prefab.init(config);
+
+    prefab.pollStatus = {status: 'pending'};
+    await prefab.init(config);
+    expect(prefab.pollStatus).toEqual({status: 'stopped'});
+  });
 });
 
 describe('setConfig', () => {

--- a/src/prefab.ts
+++ b/src/prefab.ts
@@ -49,7 +49,7 @@ export const prefab = {
       throw new Error('Context must be provided');
     }
 
-    if (this.pollTimeoutId) {
+    if (this.pollTimeoutId || this.pollStatus.status === 'pending') {
       this.stopPolling();
     }
 


### PR DESCRIPTION
If the polling is queued but hasn't begun, we're in the `pending` state
with no `pollTimeoutId`. We should stop polling in this case as well.
