### PR TITLE
Call `stopPolling()` when calling `poll()`

### DIFF
--- a/src/prefab.test.ts
+++ b/src/prefab.test.ts
@@ -122,7 +122,7 @@ describe('poll', () => {
     expect(prefab.pollCount).toEqual(2);
   });
 
-  it('is reset on init', async () => {
+  it('is reset when you call poll() again', async () => {
     jest.spyOn(globalThis, 'clearTimeout');
 
     const data = {values: {}};
@@ -151,26 +151,9 @@ describe('poll', () => {
 
     const timeoutId = prefab.pollTimeoutId;
 
-    await prefab.init(config);
-    expect(prefab.pollStatus).toEqual({status: 'stopped'});
+    prefab.poll({frequencyInMs});
     expect(clearTimeout).toHaveBeenCalledWith(timeoutId);
     expect(prefab.pollTimeoutId).toBeUndefined();
-  });
-
-  it("resets on init if the polling hasn't actually started yet", async () => {
-    const data = {values: {}};
-    fetchMock.mockResponse(JSON.stringify(data));
-
-    const config: InitParams = {
-      apiKey: '1234',
-      context: new Context({user: {device: 'desktop'}}),
-    };
-
-    await prefab.init(config);
-
-    prefab.pollStatus = {status: 'pending'};
-    await prefab.init(config);
-    expect(prefab.pollStatus).toEqual({status: 'stopped'});
   });
 });
 

--- a/src/prefab.ts
+++ b/src/prefab.ts
@@ -49,10 +49,6 @@ export const prefab = {
       throw new Error('Context must be provided');
     }
 
-    if (this.pollTimeoutId || this.pollStatus.status === 'pending') {
-      this.stopPolling();
-    }
-
     this.context = context;
 
     this.loader = new Loader({
@@ -71,9 +67,7 @@ export const prefab = {
       throw new Error('Prefab not initialized. Call init() first.');
     }
 
-    if (this.pollStatus.status === 'running') {
-      throw new Error('Already polling. Call stopPolling() first.');
-    }
+    this.stopPolling();
 
     this.pollStatus = {status: 'pending'};
 


### PR DESCRIPTION
The previous fix here was still subject to some race conditions. This is
simpler anyway.
