### PR TITLE
Incremental improvement of evaluation summaries batch timing

### DIFF
--- a/src/evaluationSummaryAggregator.ts
+++ b/src/evaluationSummaryAggregator.ts
@@ -28,7 +28,7 @@ type ConfigEvaluationSummaries = {
 };
 
 type TelemetryEvent = {
-  summaries: ConfigEvaluationSummaries[];
+  summaries: ConfigEvaluationSummaries;
 };
 
 type TelemetryEvents = {
@@ -40,7 +40,7 @@ class EvaluationSummaryAggregator extends PeriodicSync<ConfigEvaluationCounter> 
   private maxKeys: number;
 
   constructor(client: typeof prefab, maxKeys: number, syncInterval?: number) {
-    super(client, "EvaluationSummaryAggregator", syncInterval);
+    super(client, "EvaluationSummaryAggregator", syncInterval ?? 30000);
 
     this.maxKeys = maxKeys;
   }
@@ -97,7 +97,7 @@ class EvaluationSummaryAggregator extends PeriodicSync<ConfigEvaluationCounter> 
     });
   }
 
-  private events(summaries: any): TelemetryEvents {
+  private events(summaries: ConfigEvaluationSummaries): TelemetryEvents {
     const event = { summaries };
 
     return {

--- a/src/exponentialBackoff.ts
+++ b/src/exponentialBackoff.ts
@@ -7,6 +7,7 @@ export class ExponentialBackoff {
 
   private delay: number;
 
+  // arguments are in seconds
   constructor(maxDelay: number, initialDelay = 2, multiplier = 2) {
     this.initialDelay = initialDelay;
     this.maxDelay = maxDelay;
@@ -17,6 +18,6 @@ export class ExponentialBackoff {
   call(): number {
     const delayValue = this.delay;
     this.delay = Math.min(this.delay * this.multiplier, this.maxDelay);
-    return delayValue;
+    return delayValue * 1000;
   }
 }

--- a/src/periodicSync.ts
+++ b/src/periodicSync.ts
@@ -64,7 +64,7 @@ abstract class PeriodicSync<T> {
       return () => syncInterval;
     }
 
-    const backoff = new ExponentialBackoff(60 * 5);
+    const backoff = new ExponentialBackoff(60 * 5, 8);
     return () => backoff.call();
   }
 


### PR DESCRIPTION
Reports evals every 30 seconds instead of using exponential backoff