### PR TITLE
feat(updateContext): Re-fetch on context updates

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,41 +5,42 @@ module.exports = {
     jest: true,
   },
   extends: [
-    'airbnb',
-    'plugin:import/typescript',
-    'plugin:@typescript-eslint/recommended',
+    "airbnb",
+    "plugin:import/typescript",
+    "plugin:@typescript-eslint/recommended",
     // Make sure this is always the last configuration in the extends array.
-    'prettier',
+    "prettier",
   ],
-  parser: '@typescript-eslint/parser',
+  parser: "@typescript-eslint/parser",
   parserOptions: {
     ecmaFeatures: {
       jsx: true,
     },
-    ecmaVersion: 'latest',
-    sourceType: 'module',
+    ecmaVersion: "latest",
+    sourceType: "module",
   },
-  plugins: ['@typescript-eslint'],
+  plugins: ["@typescript-eslint"],
   rules: {
-    'no-unused-vars': 'off', // this rule is incompatible with typescript-eslint's 'no-unused-vars
-    '@typescript-eslint/no-unused-vars': ['error', {argsIgnorePattern: '^_'}],
-    '@typescript-eslint/no-empty-function': 'off',
-    '@typescript-eslint/no-explicit-any': 'off',
-    'import/prefer-default-export': 'off',
-    'import/extensions': [
-      'error',
-      'ignorePackages',
+    "no-unused-vars": "off", // this rule is incompatible with typescript-eslint's 'no-unused-vars
+    "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
+    "@typescript-eslint/no-empty-function": "off",
+    "@typescript-eslint/no-explicit-any": "off",
+    "import/prefer-default-export": "off",
+    "import/extensions": [
+      "error",
+      "ignorePackages",
       {
-        ts: 'never',
-        tsx: 'never',
+        ts: "never",
+        tsx: "never",
       },
     ],
+    "no-underscore-dangle": ["error", { allowAfterThis: true }],
   },
   overrides: [
     {
-      files: ['*.test.ts', '*.test.tsx'],
+      files: ["*.test.ts", "*.test.tsx"],
       rules: {
-        'import/no-extraneous-dependencies': 'off',
+        "import/no-extraneous-dependencies": "off",
       },
     },
   ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Remove Identity (#38)
+- Add `updateContext` (#39)
 
 ## 0.1.19 - 2023-12-11
 

--- a/README.md
+++ b/README.md
@@ -35,15 +35,16 @@ setTimeout(ping, prefab.get('ping-delay'));
 
 Here's an explanation of each property
 
-| property      | example                             | purpose                                                                                      |
-| ------------- | ----------------------------------- | -------------------------------------------------------------------------------------------- |
-| `isEnabled`   | `prefab.isEnabled("new-logo")`      | returns a boolean (default `false`) if a feature is enabled based on the current context     |
-| `get`         | `prefab.get('retry-count')`         | returns the value of a flag or config evaluated in the current context                       |
-| `loaded`      | `if (prefab.loaded) { ... }`        | a boolean indicating whether prefab content has loaded                                       |
-| `shouldLog`   | `if (prefab.shouldLog(...)) {`      | returns a boolean indicating whether the proposed log level is valid for the current context |
-| `poll`        | `prefab.poll({frequencyInMs})`      | starts polling every `frequencyInMs` ms.                                                     |
-| `stopPolling` | `prefab.stopPolling()`              | stops the polling process                                                                    |
-| `context`     | `prefab.context = new Context(...)` | get or set the current context (after `init()`)                                              |
+| property        | example                            | purpose                                                                                      |
+| --------------- | ---------------------------------- | -------------------------------------------------------------------------------------------- |
+| `isEnabled`     | `prefab.isEnabled("new-logo")`     | returns a boolean (default `false`) if a feature is enabled based on the current context     |
+| `get`           | `prefab.get('retry-count')`        | returns the value of a flag or config evaluated in the current context                       |
+| `loaded`        | `if (prefab.loaded) { ... }`       | a boolean indicating whether prefab content has loaded                                       |
+| `shouldLog`     | `if (prefab.shouldLog(...)) {`     | returns a boolean indicating whether the proposed log level is valid for the current context |
+| `poll`          | `prefab.poll({frequencyInMs})`     | starts polling every `frequencyInMs` ms.                                                     |
+| `stopPolling`   | `prefab.stopPolling()`             | stops the polling process                                                                    |
+| `context`       | `prefab.context`                   | get the current context (after `init()`).                                                    |
+| `updateContext` | `prefab.updateContext(newContext)` | update the context and refetch. Pass `false` as a second argument to skip refetching         |
 
 ## `shouldLog()`
 
@@ -55,9 +56,14 @@ Here's an explanation of each property
 | `desiredLevel` | string | INFO                  | No             |
 | `defaultLevel` | string | ERROR                 | No             |
 
-If you've configured a level value for `loggerName` (or a parent in the dot-notation hierarchy like "my.corp.widgets") then that value will be used for comparison against the `desiredLevel`. If no configured level is found in the hierarchy for `loggerName` then the provided `defaultLevel` will be compared against `desiredLevel`.
+If you've configured a level value for `loggerName` (or a parent in the dot-notation hierarchy like
+"my.corp.widgets") then that value will be used for comparison against the `desiredLevel`. If no
+configured level is found in the hierarchy for `loggerName` then the provided `defaultLevel` will be
+compared against `desiredLevel`.
 
-If `desiredLevel` is greater than or equal to the comparison severity, then `shouldLog` returns true. If the `desiredLevel` is less than the comparison severity, then `shouldLog` will return false.
+If `desiredLevel` is greater than or equal to the comparison severity, then `shouldLog` returns
+true. If the `desiredLevel` is less than the comparison severity, then `shouldLog` will return
+false.
 
 Example usage:
 
@@ -71,11 +77,14 @@ if (shouldLog({ loggerName, desiredLevel, defaultLevel })) {
 }
 ```
 
-If no log level value is configured in Prefab for "my.corp.widgets.modal" or higher in the hierarchy, then the `console.info` will not happen. If the value is configured and is INFO or more verbose, the `console.info` will happen.
+If no log level value is configured in Prefab for "my.corp.widgets.modal" or higher in the
+hierarchy, then the `console.info` will not happen. If the value is configured and is INFO or more
+verbose, the `console.info` will happen.
 
 ## `poll()`
 
-After `prefab.init()`, you can start polling. Polling uses the context you defined in `init` by default. You can update the context for future polling by setting it on the `prefab` object.
+After `prefab.init()`, you can start polling. Polling uses the context you defined in `init` by
+default. You can update the context for future polling by setting it on the `prefab` object.
 
 ```javascript
 // some time after init
@@ -91,7 +100,8 @@ prefab.context = new Context({...prefab.context, user: { email: user.email, key:
 
 ## Usage in your test suite
 
-In your test suite, you probably want to skip the `prefab.init` altogether and instead use `prefab.setConfig` to set up your test state.
+In your test suite, you probably want to skip the `prefab.init` altogether and instead use
+`prefab.setConfig` to set up your test state.
 
 ```javascript
 it("shows the turbo button when the feature is enabled", () => {

--- a/build.sh
+++ b/build.sh
@@ -7,6 +7,6 @@ version=$(node -e "console.log(require('./package.json').version)")
 echo "Building version $version"
 
 echo "// THIS FILE IS GENERATED" >src/version.ts
-echo "export default '$version';" >>src/version.ts
+echo "export default \"$version\";" >>src/version.ts
 
 tsc

--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,7 @@
-import { prefab } from "./src/prefab";
+import { prefab, Prefab } from "./src/prefab";
 import { Config } from "./src/config";
 import ConfigValue from "./src/configValue";
 import Context from "./src/context";
 import version from "./src/version";
 
-export { prefab, Config, ConfigValue, Context, version };
+export { prefab, Config, ConfigValue, Context, Prefab, version };

--- a/src/afterEvaluationCallback.test.ts
+++ b/src/afterEvaluationCallback.test.ts
@@ -1,117 +1,102 @@
 // This is in its own file for jest concurrency isolation purposes
 
-import {prefab, Context} from '../index';
+import { Prefab, Context } from "../index";
 
 const exampleContext = new Context({
-  user: {firstName: 'Fred', lastName: 'Jones', id: 10001},
-  team: {name: 'Sales', isCostCenter: false},
+  user: { firstName: "Fred", lastName: "Jones", id: 10001 },
+  team: { name: "Sales", isCostCenter: false },
 });
+
+const setContext = async (prefab: Prefab, contexts: Context) => {
+  // eslint-disable-next-line no-param-reassign
+  prefab.loader = {} as unknown as Prefab["loader"];
+  await prefab.updateContext(contexts, true);
+};
 
 const waitForAsyncCall = async () => {
   // eslint-disable-next-line no-promise-executor-return
   await new Promise((r) => setTimeout(r, 1));
 };
 
-beforeEach(() => {
-  prefab.context = undefined;
-  prefab.loaded = false;
-  prefab.configs = {};
-});
-
-afterEach(() => {
-  prefab.context = undefined;
-});
-
-describe('afterEvaluationCallback', () => {
-  test('get with no Context', async () => {
+describe("afterEvaluationCallback", () => {
+  test("get with no Context", async () => {
     const callback = jest.fn();
 
+    const prefab = new Prefab();
     prefab.afterEvaluationCallback = callback;
 
-    prefab.setConfig({
-      turbo: {
-        double: 2.5,
-      },
-    });
+    prefab.setConfig({ turbo: { double: 2.5 } });
 
     expect(callback).not.toHaveBeenCalled();
 
-    prefab.get('turbo');
+    prefab.get("turbo");
 
     expect(callback).not.toHaveBeenCalled();
 
     await waitForAsyncCall();
 
-    expect(callback).toHaveBeenCalledWith('turbo', 2.5, undefined);
+    expect(callback).toHaveBeenCalledWith("turbo", 2.5, { contexts: {} });
   });
 
-  test('get with context', async () => {
+  test("get with context", async () => {
     const callback = jest.fn();
 
-    prefab.context = exampleContext;
+    const prefab = new Prefab();
+    setContext(prefab, exampleContext);
+
     prefab.afterEvaluationCallback = callback;
 
-    prefab.setConfig({
-      turbo: {
-        double: 2.5,
-      },
-    });
+    prefab.setConfig({ turbo: { double: 2.5 } });
 
     expect(callback).not.toHaveBeenCalled();
 
-    prefab.get('turbo');
+    prefab.get("turbo");
 
     expect(callback).not.toHaveBeenCalled();
 
     await waitForAsyncCall();
 
-    expect(callback).toHaveBeenCalledWith('turbo', 2.5, exampleContext);
+    expect(callback).toHaveBeenCalledWith("turbo", 2.5, exampleContext);
   });
 
-  test('isEnabled with no Context', async () => {
+  test("isEnabled with no Context", async () => {
     const callback = jest.fn();
 
+    const prefab = new Prefab();
     prefab.afterEvaluationCallback = callback;
 
     // it is false when no config is loaded
-    expect(prefab.isEnabled('foo')).toBe(false);
+    expect(prefab.isEnabled("foo")).toBe(false);
 
     await waitForAsyncCall();
-    expect(callback).toHaveBeenCalledWith('foo', undefined, undefined);
+    expect(callback).toHaveBeenCalledWith("foo", undefined, { contexts: {} });
 
-    prefab.setConfig({
-      foo: {
-        bool: true,
-      },
-    });
+    prefab.setConfig({ foo: { bool: true } });
 
-    expect(prefab.isEnabled('foo')).toBe(true);
+    expect(prefab.isEnabled("foo")).toBe(true);
 
     await waitForAsyncCall();
-    expect(callback).toHaveBeenCalledWith('foo', true, undefined);
+    expect(callback).toHaveBeenCalledWith("foo", true, { contexts: {} });
   });
 
-  test('isEnabled with Context', async () => {
+  test("isEnabled with Context", async () => {
     const callback = jest.fn();
+    const prefab = new Prefab();
 
-    prefab.context = exampleContext;
+    await setContext(prefab, exampleContext);
     prefab.afterEvaluationCallback = callback;
 
     // it is false when no config is loaded
-    expect(prefab.isEnabled('foo')).toBe(false);
+    expect(prefab.isEnabled("foo")).toBe(false);
 
     await waitForAsyncCall();
-    expect(callback).toHaveBeenCalledWith('foo', undefined, exampleContext);
+    expect(callback).toHaveBeenCalledWith("foo", undefined, exampleContext);
 
-    prefab.setConfig({
-      foo: {
-        bool: true,
-      },
-    });
+    prefab.setConfig({ foo: { bool: true } });
 
-    expect(prefab.isEnabled('foo')).toBe(true);
+    expect(prefab.isEnabled("foo")).toBe(true);
 
     await waitForAsyncCall();
-    expect(callback).toHaveBeenCalledWith('foo', true, exampleContext);
+    expect(callback).toHaveBeenCalledWith("foo", true, exampleContext);
   });
 });


### PR DESCRIPTION
```
prefab.updateContext(newContext)
```

This also moves to a class-based approach (of which `prefab` is an
instance) to prevent accidentally doing things like `prefab.content =
...` without getting the update behavior. You can intentionally opt-out
of the update behavior with `false` as a second param to `updateContext`
