### PR TITLE
collectEvaluationSummaries is now opt-out

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "prettier": "prettier . -l",
     "prettier:fix": "npm run prettier --write .",
     "release": "npm run prettier:fix; npm run lint:fix; npm run test",
-    "test": "npm run build && jest --verbose dist/",
+    "test": "npm run build && jest --verbose --detectOpenHandles dist/",
     "version": "echo 'version' && npm run release && npm run prettier:fix; git add src/version.ts"
   },
   "repository": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,7 @@ const valueFor = (value: { [key: string]: any }, type: string, key: string): Con
       try {
         return JSON.parse(value[type].json);
       } catch (e) {
+        // eslint-disable-next-line no-console
         console.error(`Error parsing JSON from Prefab config ${key}`, e, value[type].json);
         return value[type].json;
       }

--- a/src/periodicSync.ts
+++ b/src/periodicSync.ts
@@ -12,6 +12,8 @@ abstract class PeriodicSync<T> {
 
   private name: string;
 
+  private timeoutID: ReturnType<typeof setTimeout> | undefined;
+
   constructor(client: typeof prefab, name: string, syncInterval?: number) {
     this.client = client;
     this.name = name;
@@ -19,6 +21,10 @@ abstract class PeriodicSync<T> {
     this.startAt = new Date();
 
     this.startPeriodicSync(syncInterval);
+  }
+
+  stop(): void {
+    clearTimeout(this.timeoutID);
   }
 
   sync(): void {
@@ -53,7 +59,7 @@ abstract class PeriodicSync<T> {
     this.logInternal(
       `Scheduled next sync in ${interval} ms for ${this.name} instanceHash=${this.client.instanceHash}`
     );
-    setTimeout(() => {
+    this.timeoutID = setTimeout(() => {
       this.sync();
       this.scheduleNextSync(); // Schedule the next sync after the current one completes
     }, interval);

--- a/src/prefab.ts
+++ b/src/prefab.ts
@@ -43,7 +43,7 @@ export class Prefab {
 
   private _instanceHash: string = uuid();
 
-  private collectEvaluationSummaries = false;
+  private collectEvaluationSummaries = true;
 
   private collectLoggerNames = false;
 
@@ -66,7 +66,7 @@ export class Prefab {
     apiEndpoint,
     timeout = undefined,
     afterEvaluationCallback = () => {},
-    collectEvaluationSummaries = false,
+    collectEvaluationSummaries = true,
     collectLoggerNames = false,
     clientVersionString = `prefab-cloud-js-${version}`,
   }: InitParams) {
@@ -208,6 +208,13 @@ export class Prefab {
     this._pollStatus = { status: "stopped" };
   }
 
+  stopTelemetry() {
+    if (this.telemetryUploader) {
+      this.evalutionSummaryAggregator?.stop();
+      this.loggerAggregator?.stop();
+    }
+  }
+
   setConfig(rawValues: { [key: string]: any }) {
     this._configs = Config.digest(rawValues);
     this.loaded = true;
@@ -251,7 +258,10 @@ export class Prefab {
       return undefined;
     }
 
-    if (!value.hasOwnProperty("seconds") || !value.hasOwnProperty("ms")) {
+    if (
+      !Object.prototype.hasOwnProperty.call(value, "seconds") ||
+      !Object.prototype.hasOwnProperty.call(value, "ms")
+    ) {
       throw new Error(`Value for key "${key}" is not a duration`);
     }
 
@@ -270,6 +280,14 @@ export class Prefab {
     }
 
     return shouldLog({ ...args, get: this.get.bind(this) });
+  }
+
+  isCollectingEvaluationSummaries(): boolean {
+    return this.collectEvaluationSummaries;
+  }
+
+  isCollectingLoggerNames(): boolean {
+    return this.collectLoggerNames;
   }
 }
 


### PR DESCRIPTION
To ensure you get the best out-of-the-box experience, evaluation
summaries are now enabled by default. These summaries only contain data
about which value is served and how often. No context/PII is present.

You can opt-out of this behavior by passing `collectEvaluationSummaries:
false` into the `init` call.

I've also smuggled in a little test clean-up and coverage.
