### PR TITLE
Improves prefix for internal logger names

### DIFF
--- a/src/periodicSync.ts
+++ b/src/periodicSync.ts
@@ -75,11 +75,17 @@ abstract class PeriodicSync<T> {
   }
 
   protected logInternal(message: string): void {
+    const loggerName = `${this.client.clientNameString}.prefab.${this.name}`;
+
     if (
-      this.client.shouldLog({ loggerName: this.name, desiredLevel: "debug", defaultLevel: "error" })
+      this.client.shouldLog({
+        loggerName,
+        desiredLevel: "debug",
+        defaultLevel: "error",
+      })
     ) {
       // eslint-disable-next-line no-console
-      console.log(message);
+      console.log(`${loggerName}: ${message}`);
     }
   }
 }

--- a/src/prefab.ts
+++ b/src/prefab.ts
@@ -22,6 +22,7 @@ type InitParams = {
   collectEvaluationSummaries?: boolean;
   collectLoggerNames?: boolean;
   collectContextMode?: CollectContextModeType;
+  clientNameString?: string;
   clientVersionString?: string;
 };
 
@@ -52,6 +53,8 @@ export class Prefab {
 
   private loggerAggregator: LoggerAggregator | undefined;
 
+  public clientNameString = "prefab-cloud-js";
+
   public loaded = false;
 
   public loader: Loader | undefined;
@@ -70,7 +73,8 @@ export class Prefab {
     collectEvaluationSummaries = true,
     collectLoggerNames = false,
     collectContextMode = "PERIODIC_EXAMPLE",
-    clientVersionString = `prefab-cloud-js-${version}`,
+    clientNameString = "prefab-cloud-js",
+    clientVersionString = version,
   }: InitParams) {
     const context = providedContext ?? this.context;
 
@@ -80,20 +84,23 @@ export class Prefab {
 
     this._context = context;
 
+    this.clientNameString = clientNameString;
+    const clientNameAndVersionString = `${clientNameString}-${clientVersionString}`;
+
     this.loader = new Loader({
       apiKey,
       context,
       endpoints,
       timeout,
       collectContextMode,
-      clientVersion: clientVersionString,
+      clientVersion: clientNameAndVersionString,
     });
 
     this._telemetryUploader = new TelemetryUploader({
       apiKey,
       apiEndpoint,
       timeout,
-      clientVersion: clientVersionString,
+      clientVersion: clientNameAndVersionString,
     });
 
     this.collectEvaluationSummaries = collectEvaluationSummaries;


### PR DESCRIPTION
Adds client name and prefab prefix, e.g. "prefab-cloud-js.prefab.LOGGER_NAME"