### PR TITLE
Handle non-Latin1 characters in Base64 encoding

### DIFF
--- a/src/base64Encode.ts
+++ b/src/base64Encode.ts
@@ -1,6 +1,12 @@
 const base64Encode = (obj: string) => {
   if (typeof window !== "undefined") {
-    return window.btoa(obj);
+    if (typeof TextEncoder === "undefined") {
+      return window.btoa(obj);
+    }
+
+    const bytes = new TextEncoder().encode(obj);
+    const binString = Array.from(bytes, (byte) => String.fromCodePoint(byte)).join("");
+    return btoa(binString);
   }
 
   return Buffer.from(obj).toString("base64");


### PR DESCRIPTION
Hat tip to https://developer.mozilla.org/en-US/docs/Glossary/Base64#the_unicode_problem
