### PR TITLE
Guard against potential race conditions with abort controllers

### DIFF
--- a/src/telemetryUploader.ts
+++ b/src/telemetryUploader.ts
@@ -1,4 +1,4 @@
-import { headers, DEFAULT_TIMEOUT } from "./apiHelpers";
+import { DEFAULT_TIMEOUT, headers } from "./apiHelpers";
 
 export type TelemetryUploaderParams = {
   apiKey: string;
@@ -41,6 +41,7 @@ export default class TelemetryUploader {
   postToEndpoint(options: object, resolve: (value: any) => void, reject: (value: any) => void) {
     const controller = new AbortController() as AbortController;
     const signal = controller?.signal;
+    let isAborted = false;
 
     const url = TelemetryUploader.postUrl(this.apiEndpoint);
 
@@ -81,7 +82,10 @@ export default class TelemetryUploader {
       });
 
     this.abortTimeoutId = setTimeout(() => {
-      controller.abort();
+      if (!isAborted) {
+        isAborted = true;
+        controller.abort();
+      }
     }, this.timeout);
   }
 


### PR DESCRIPTION
Compass recorded two Sentry errors related to abort logic in the client
https://monterey-ai.sentry.io/share/issue/af45df19075f4488857359a3fcda9fbd/
https://monterey-ai.sentry.io/share/issue/75494427e5754e98a1a03ea518fb8281/

Adding some guards to avoid a possible race condition leading to multiple aborts.